### PR TITLE
Update graphql peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {
-    "graphql": "^0.9.0 || ^0.10.0"
+    "graphql": "0.9 - 0.13"
   },
   "devDependencies": {
     "babel-jest": "^20.0.3",


### PR DESCRIPTION
Currently, with the latest version it gives a warning:

```
warning " > rollup-plugin-graphql@0.1.0" has incorrect peer dependency "graphql@^0.9.0 || ^0.10.0".
```