### PR TITLE
Update plugin to work with latest rollup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
     "jest"
   ],
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2018,
     "sourceType": "module"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-- '4.0'
-- '5.0'
-- '6.0'
+- '8.0'
 deploy:
   provider: npm
   email: kamil.kisiela@gmail.com

--- a/package.json
+++ b/package.json
@@ -39,18 +39,18 @@
     "rollup-pluginutils": "^2.0.1"
   },
   "peerDependencies": {
-    "graphql": "^0.9.0 || ^0.10.0"
+    "graphql": ">=0.9.0"
   },
   "devDependencies": {
-    "babel-jest": "^20.0.3",
-    "eslint": "^3.19.0",
+    "babel-jest": "^24.0.0",
+    "eslint": "^5.13.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jest": "^20.0.3",
-    "graphql": "^0.10.1",
-    "jest": "^20.0.4",
-    "rollup": "^0.43.0",
-    "rollup-plugin-buble": "^0.15.0",
-    "rollup-plugin-node-resolve": "^3.0.0"
+    "graphql": "^14.1.1",
+    "jest": "^24.0.0",
+    "rollup": "^1.1.2",
+    "rollup-plugin-buble": "^0.19.6",
+    "rollup-plugin-node-resolve": "^4.0.0"
   },
   "jest": {
     "testRegex": "/tests/.*\\.spec.js$",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,10 +5,10 @@ const pkg = require('./package.json');
 const external = Object.keys(pkg.dependencies);
 
 export default {
-	entry: 'src/index.js',
-	targets: [
-		{ dest: pkg.main, format: 'cjs' },
-		{ dest: pkg.module, format: 'es' }
+	input: 'src/index.js',
+	output: [
+		{ file: pkg.main, format: 'cjs' },
+		{ file: pkg.module, format: 'es' }
 	],
 	plugins: [ buble() ],
 	external,

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,11 @@
-import {
-  createFilter
-} from 'rollup-pluginutils';
+import { createFilter } from 'rollup-pluginutils';
 import loader from 'graphql-tag/loader';
 
 import toESModules from './toESModules';
 
-export default function graphql(options = {}) {
+export default function graphql({ include, exclude } = {}) {
   // path filter
-  const filter = createFilter(options.include, options.exclude);
+  const filter = createFilter(include, exclude);
   // only .graphql and .gql files
   const filterExt = /\.(graphql|gql)$/i;
 
@@ -19,7 +17,7 @@ export default function graphql(options = {}) {
 
       // XXX: this.cachable() in graphql-tag/loader
       const code = toESModules(loader.call({
-        cacheable() {}
+        cacheable() { }
       }, source));
 
       return {

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,11 @@ export default function graphql({ include, exclude } = {}) {
         cacheable() { }
       }, source));
 
+      const map = { mappings: '' };
+
       return {
-        code
+        code,
+        map
       };
     }
   };

--- a/src/toESModules.js
+++ b/src/toESModules.js
@@ -11,7 +11,9 @@ export default function(source) {
 }
 
 function replaceModuleExports(source) {
-  return source.replace('module.exports = doc', 'export default doc');
+  return source
+    .replace('module.exports = doc', 'export default doc')
+    .replace(/module\.exports\["(.*)"] = oneQuery\(doc, "(.*)"\)/, (match, g1, g2) => `export const ${g1} = oneQuery(doc, "${g2}")`);
 }
 
 function replaceRequires(source) {
@@ -20,7 +22,7 @@ function replaceRequires(source) {
 
   // replace a require statement with a variable
   source = source.replace(/require\(([^)]+)\)/ig, (match, path) => {
-    path = path.replace(/[\"\']+/g, '');
+    path = path.replace(/["']+/g, '');
 
     if (!imports[path]) {
       imports[path] = `frgmt${++index}`;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -4,42 +4,38 @@ const graphql = require('..');
 process.chdir(__dirname);
 
 describe('plugin', () => {
-  it('should parse a simple graphql file', () => {
-    return rollup.rollup({
-      entry: 'samples/basic/index.js',
+  it('should parse a simple graphql file', async function() {
+    const bundle = await rollup.rollup({
+      input: 'samples/basic/index.js',
       plugins: [graphql()]
-    }).then((bundle) => {
-      const generated = bundle.generate({
-        format: 'cjs'
-      });
-      const code = generated.code;
-      const exports = {};
-      const fn = new Function('exports', code);
-
-      fn(exports);
-
-      expect(exports.doc).toBeDefined();
-      expect(exports.doc.kind).toBe('Document');
     });
+    const { output: [{ code }] } = await bundle.generate({
+      format: 'cjs'
+    });
+    const exports = {};
+    const fn = new Function('exports', code);
+
+    fn(exports);
+
+    expect(exports.doc).toBeDefined();
+    expect(exports.doc.kind).toBe('Document');
   });
 
-  it('should include a fragment', () => {
-    return rollup.rollup({
-      entry: 'samples/fragments/index.js',
+  it('should include a fragment', async function() {
+    const bundle = await rollup.rollup({
+      input: 'samples/fragments/index.js',
       plugins: [graphql()]
-    }).then((bundle) => {
-      const generated = bundle.generate({
-        format: 'cjs'
-      });
-      const code = generated.code;
-      const exports = {};
-      const fn = new Function('exports', code);
-
-      fn(exports);
-
-      expect(exports.doc).toBeDefined();
-      expect(exports.doc.kind).toBe('Document');
-      expect(exports.doc.definitions[1].name.value).toBe('HeroFragment');
     });
+    const { output: [{ code }] } = await bundle.generate({
+      format: 'cjs'
+    });
+    const exports = {};
+    const fn = new Function('exports', code);
+
+    fn(exports);
+
+    expect(exports.doc).toBeDefined();
+    expect(exports.doc.kind).toBe('Document');
+    expect(exports.doc.definitions[1].name.value).toBe('HeroFragment');
   });
 });

--- a/tests/samples/basic/index.js
+++ b/tests/samples/basic/index.js
@@ -1,5 +1,1 @@
-import doc from './basic.graphql';
-
-export {
-  doc
-};
+export { default as doc } from './basic.graphql';

--- a/tests/samples/fragments/index.js
+++ b/tests/samples/fragments/index.js
@@ -1,5 +1,1 @@
-import doc from './allHeroesQuery.graphql';
-
-export {
-  doc
-};
+export { default as doc } from './allHeroesQuery.graphql';


### PR DESCRIPTION
Removes webpack loader and cjs to esm regex code, just outputs a parsed AST as default export instead.