### PR TITLE
Deprecate this plugin in favor of the offical one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# This plugin is deprecated since one of its fork is now part of the official Rollup plugins, see [`@rollup/plugin-graphql`](https://www.npmjs.com/package/@rollup/plugin-graphql).
+
+
 # rollup-plugin-graphql
 
 Convert GraphQL files to ES6 modules:


### PR DESCRIPTION
Hi, I know this repository is abandoned, but we recently added [my fork](https://github.com/Kocal/rollup-plugin-graphql) into the official Rollup plugins repository, see: 
- https://www.npmjs.com/package/@rollup/plugin-graphql
- https://github.com/rollup/plugins/pull/585

It would be nice to warn users about it.
Thanks!